### PR TITLE
Upgrade to spring-data 3.0

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -1,4 +1,4 @@
-name: "CI - JDK 11 Build"
+name: "CI - JDK 17 Build"
 
 on:
   push:
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build-jdk11:
-    name: "JDK 11 Build"
+    name: "JDK 17 Build"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build
         run: mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-spring-data-api</artifactId>
-  <version>2.1.SP2-SNAPSHOT</version>
+  <version>3.0.Final-SNAPSHOT</version>
 
   <name>Spring Data dependencies for Quarkus Spring Data JPA extension</name>
   <description>The minimum dependencies to reduce the footprint of Quarkus applications using the Spring Data JPA extension</description>
@@ -41,8 +41,8 @@
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <spring-data.version>2.1.9.RELEASE</spring-data.version>
-    <spring-data-rest.version>3.1.9.RELEASE</spring-data-rest.version>
+    <spring-data.version>3.0.4</spring-data.version>
+    <spring-data-rest.version>4.0.4</spring-data-rest.version>
   </properties>
 
   <packaging>pom</packaging>

--- a/quarkus-spring-data-commons-api/pom.xml
+++ b/quarkus-spring-data-commons-api/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-api</artifactId>
-        <version>2.1.SP2-SNAPSHOT</version>
+        <version>3.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-data-commons-api</artifactId>
-    <version>2.1.SP2-SNAPSHOT</version>
+    <version>3.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -56,6 +56,8 @@
                                         <include>org/springframework/data/domain/Auditable**</include>
                                         <include>org/springframework/data/domain/Persistable**</include>
                                         <include>org/springframework/data/repository/CrudRepository**</include>
+                                        <include>org/springframework/data/repository/ListCrudRepository**</include>
+                                        <include>org/springframework/data/repository/ListPagingAndSortingRepository**</include>
                                         <include>org/springframework/data/repository/PagingAndSortingRepository**</include>
                                         <include>org/springframework/data/repository/NoRepositoryBean**</include>
                                         <include>org/springframework/data/repository/query/QueryByExampleExecutor**</include>
@@ -66,6 +68,8 @@
                                         <include>org/springframework/data/domain/Example**</include>
                                         <include>org/springframework/data/domain/AbstractPageRequest**</include>
                                         <include>org/springframework/data/domain/Chunk**</include>
+                                        <include>org/springframework/data/repository/query/FluentQuery**</include>
+                                        <include>org/springframework/data/util/StreamUtils**</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/quarkus-spring-data-jpa-api/pom.xml
+++ b/quarkus-spring-data-jpa-api/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-api</artifactId>
-        <version>2.1.SP2-SNAPSHOT</version>
+        <version>3.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-data-jpa-api</artifactId>
-    <version>2.1.SP2-SNAPSHOT</version>
+    <version>3.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/quarkus-spring-data-rest-api/pom.xml
+++ b/quarkus-spring-data-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-api</artifactId>
-        <version>2.1.SP2-SNAPSHOT</version>
+        <version>3.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/32027

[These diagrams on stackoverflow](https://stackoverflow.com/questions/14014086/what-is-difference-between-crudrepository-and-jparepository-interfaces-in-spring/74512964#74512964) explains the breaking changes in terms of repository interfaces.